### PR TITLE
feat: add Rust model modules and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 build/
 xcuserdata/
 Package.resolved
+target/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
 name = "mist-core"
 version = "0.1.0"
 
@@ -11,4 +23,79 @@ name = "mist-rs"
 version = "0.1.0"
 dependencies = [
  "mist-core",
+ "serde",
+ "serde_json",
 ]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"

--- a/mist-rs/Cargo.toml
+++ b/mist-rs/Cargo.toml
@@ -5,3 +5,5 @@ edition = "2021"
 
 [dependencies]
 mist-core = { path = "../core" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/mist-rs/src/lib.rs
+++ b/mist-rs/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod model;

--- a/mist-rs/src/model/app_icon.rs
+++ b/mist-rs/src/model/app_icon.rs
@@ -1,0 +1,31 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum AppIcon {
+    Monterey,
+    Ventura,
+    Sonoma,
+    Sequoia,
+}
+
+impl Default for AppIcon {
+    fn default() -> Self {
+        AppIcon::Sequoia
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn serialize_round_trip() {
+        let icon = AppIcon::Ventura;
+        let json = serde_json::to_string(&icon).unwrap();
+        assert_eq!(json, "\"Ventura\"");
+        let de: AppIcon = serde_json::from_str(&json).unwrap();
+        assert_eq!(de, icon);
+    }
+}

--- a/mist-rs/src/model/architecture.rs
+++ b/mist-rs/src/model/architecture.rs
@@ -1,0 +1,24 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Architecture {
+    #[serde(rename = "arm64")]
+    AppleSilicon,
+    #[serde(rename = "x86_64")]
+    Intel,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn serialize_round_trip() {
+        let arch = Architecture::Intel;
+        let json = serde_json::to_string(&arch).unwrap();
+        assert_eq!(json, "\"x86_64\"");
+        let de: Architecture = serde_json::from_str(&json).unwrap();
+        assert_eq!(de, arch);
+    }
+}

--- a/mist-rs/src/model/catalog.rs
+++ b/mist-rs/src/model/catalog.rs
@@ -1,0 +1,39 @@
+use serde::{Deserialize, Serialize};
+
+use super::catalog_type::CatalogType;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Catalog {
+    #[serde(rename = "type")]
+    pub catalog_type: CatalogType,
+    pub standard: bool,
+    pub customer_seed: bool,
+    pub developer_seed: bool,
+    pub public_seed: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn deserialize_catalog() {
+        let data = r#"{
+            "type": "macOS Ventura",
+            "standard": true,
+            "customer_seed": false,
+            "developer_seed": false,
+            "public_seed": false
+        }"#;
+        let catalog: Catalog = serde_json::from_str(data).unwrap();
+        assert!(matches!(catalog.catalog_type, CatalogType::Ventura));
+        assert!(catalog.standard);
+        assert!(!catalog.customer_seed);
+        assert!(!catalog.developer_seed);
+        assert!(!catalog.public_seed);
+        let serialized = serde_json::to_string(&catalog).unwrap();
+        let round: Catalog = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(catalog, round);
+    }
+}

--- a/mist-rs/src/model/catalog_seed_type.rs
+++ b/mist-rs/src/model/catalog_seed_type.rs
@@ -1,0 +1,25 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum CatalogSeedType {
+    Standard,
+    Customer,
+    Developer,
+    Public,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn serialize_round_trip() {
+        let seed = CatalogSeedType::Developer;
+        let json = serde_json::to_string(&seed).unwrap();
+        assert_eq!(json, "\"Developer\"");
+        let de: CatalogSeedType = serde_json::from_str(&json).unwrap();
+        assert_eq!(de, seed);
+    }
+}

--- a/mist-rs/src/model/catalog_type.rs
+++ b/mist-rs/src/model/catalog_type.rs
@@ -1,0 +1,30 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CatalogType {
+    #[serde(rename = "macOS Sequoia")]
+    Sequoia,
+    #[serde(rename = "macOS Sonoma")]
+    Sonoma,
+    #[serde(rename = "macOS Ventura")]
+    Ventura,
+    #[serde(rename = "macOS Monterey")]
+    Monterey,
+    #[serde(rename = "macOS Big Sur")]
+    BigSur,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn serialize_round_trip() {
+        let typ = CatalogType::Ventura;
+        let json = serde_json::to_string(&typ).unwrap();
+        assert_eq!(json, "\"macOS Ventura\"");
+        let de: CatalogType = serde_json::from_str(&json).unwrap();
+        assert_eq!(de, typ);
+    }
+}

--- a/mist-rs/src/model/download_type.rs
+++ b/mist-rs/src/model/download_type.rs
@@ -1,0 +1,23 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum DownloadType {
+    Firmware,
+    Installer,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn serialize_round_trip() {
+        let t = DownloadType::Firmware;
+        let json = serde_json::to_string(&t).unwrap();
+        assert_eq!(json, "\"Firmware\"");
+        let de: DownloadType = serde_json::from_str(&json).unwrap();
+        assert_eq!(de, t);
+    }
+}

--- a/mist-rs/src/model/export_list_type.rs
+++ b/mist-rs/src/model/export_list_type.rs
@@ -1,0 +1,25 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ExportListType {
+    Csv,
+    Json,
+    Plist,
+    Yaml,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn serialize_round_trip() {
+        let t = ExportListType::Csv;
+        let json = serde_json::to_string(&t).unwrap();
+        assert_eq!(json, "\"csv\"");
+        let de: ExportListType = serde_json::from_str(&json).unwrap();
+        assert_eq!(de, t);
+    }
+}

--- a/mist-rs/src/model/firmware_alert_type.rs
+++ b/mist-rs/src/model/firmware_alert_type.rs
@@ -1,0 +1,26 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum FirmwareAlertType {
+    #[serde(rename = "Compatiblity")]
+    Compatibility,
+    #[serde(rename = "Helper Tool")]
+    HelperTool,
+    Error,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn serialize_round_trip() {
+        let t = FirmwareAlertType::HelperTool;
+        let json = serde_json::to_string(&t).unwrap();
+        assert_eq!(json, "\"Helper Tool\"");
+        let de: FirmwareAlertType = serde_json::from_str(&json).unwrap();
+        assert_eq!(de, t);
+    }
+}

--- a/mist-rs/src/model/installer_alert_type.rs
+++ b/mist-rs/src/model/installer_alert_type.rs
@@ -1,0 +1,30 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum InstallerAlertType {
+    #[serde(rename = "Compatiblity")]
+    Compatibility,
+    #[serde(rename = "Helper Tool")]
+    HelperTool,
+    #[serde(rename = "Full Disk Access")]
+    FullDiskAccess,
+    #[serde(rename = "Cache Directory")]
+    CacheDirectory,
+    Error,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn serialize_round_trip() {
+        let t = InstallerAlertType::Error;
+        let json = serde_json::to_string(&t).unwrap();
+        assert_eq!(json, "\"Error\"");
+        let de: InstallerAlertType = serde_json::from_str(&json).unwrap();
+        assert_eq!(de, t);
+    }
+}

--- a/mist-rs/src/model/installer_export_type.rs
+++ b/mist-rs/src/model/installer_export_type.rs
@@ -1,0 +1,26 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum InstallerExportType {
+    Application,
+    DiskImage,
+    #[serde(rename = "ISO")]
+    Iso,
+    Package,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn serialize_round_trip() {
+        let t = InstallerExportType::Iso;
+        let json = serde_json::to_string(&t).unwrap();
+        assert_eq!(json, "\"ISO\"");
+        let de: InstallerExportType = serde_json::from_str(&json).unwrap();
+        assert_eq!(de, t);
+    }
+}

--- a/mist-rs/src/model/installer_sheet_type.rs
+++ b/mist-rs/src/model/installer_sheet_type.rs
@@ -1,0 +1,26 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum InstallerSheetType {
+    Download,
+    #[serde(rename = "Volume Selection")]
+    VolumeSelection,
+    #[serde(rename = "Create Bootable Installer")]
+    CreateBootableInstaller,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn serialize_round_trip() {
+        let t = InstallerSheetType::VolumeSelection;
+        let json = serde_json::to_string(&t).unwrap();
+        assert_eq!(json, "\"Volume Selection\"");
+        let de: InstallerSheetType = serde_json::from_str(&json).unwrap();
+        assert_eq!(de, t);
+    }
+}

--- a/mist-rs/src/model/installer_volume.rs
+++ b/mist-rs/src/model/installer_volume.rs
@@ -1,0 +1,28 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InstallerVolume {
+    pub id: String,
+    pub name: String,
+    pub path: String,
+    pub capacity: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn serialize_round_trip() {
+        let vol = InstallerVolume {
+            id: "vol1".into(),
+            name: "Volume".into(),
+            path: "/Volumes/Volume".into(),
+            capacity: 1024,
+        };
+        let json = serde_json::to_string(&vol).unwrap();
+        let de: InstallerVolume = serde_json::from_str(&json).unwrap();
+        assert_eq!(vol, de);
+    }
+}

--- a/mist-rs/src/model/log_entry.rs
+++ b/mist-rs/src/model/log_entry.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+
+use super::log_level::LogLevel;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LogEntry {
+    pub id: String,
+    pub timestamp: String,
+    pub level: LogLevel,
+    pub message: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn deserialize_log_entry() {
+        let data = r#"{
+            "id": "123",
+            "timestamp": "2024-02-11T00:00:00Z",
+            "level": "info",
+            "message": "Message"
+        }"#;
+        let entry: LogEntry = serde_json::from_str(data).unwrap();
+        assert_eq!(entry.id, "123");
+        assert!(matches!(entry.level, LogLevel::Info));
+        assert_eq!(entry.message, "Message");
+        let serialized = serde_json::to_string(&entry).unwrap();
+        let round: LogEntry = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(round, entry);
+    }
+}

--- a/mist-rs/src/model/log_level.rs
+++ b/mist-rs/src/model/log_level.rs
@@ -1,0 +1,24 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LogLevel {
+    Info,
+    Warning,
+    Error,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn serialize_round_trip() {
+        let level = LogLevel::Warning;
+        let json = serde_json::to_string(&level).unwrap();
+        assert_eq!(json, "\"warning\"");
+        let de: LogLevel = serde_json::from_str(&json).unwrap();
+        assert_eq!(de, level);
+    }
+}

--- a/mist-rs/src/model/mod.rs
+++ b/mist-rs/src/model/mod.rs
@@ -1,0 +1,15 @@
+pub mod app_icon;
+pub mod architecture;
+pub mod catalog_seed_type;
+pub mod catalog_type;
+pub mod catalog;
+pub mod download_type;
+pub mod export_list_type;
+pub mod installer_export_type;
+pub mod installer_sheet_type;
+pub mod installer_alert_type;
+pub mod firmware_alert_type;
+pub mod log_level;
+pub mod log_entry;
+pub mod installer_volume;
+pub mod package;

--- a/mist-rs/src/model/package.rs
+++ b/mist-rs/src/model/package.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Package {
+    #[serde(rename = "URL")]
+    pub url: String,
+    #[serde(rename = "Size")]
+    pub size: i64,
+    #[serde(rename = "IntegrityDataURL")]
+    pub integrity_data_url: Option<String>,
+    #[serde(rename = "IntegrityDataSize")]
+    pub integrity_data_size: Option<i64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn deserialize_package() {
+        let data = r#"{
+            "URL": "https://example.com/file.pkg",
+            "Size": 123,
+            "IntegrityDataURL": null,
+            "IntegrityDataSize": null
+        }"#;
+        let pkg: Package = serde_json::from_str(data).unwrap();
+        assert_eq!(pkg.url, "https://example.com/file.pkg");
+        assert_eq!(pkg.size, 123);
+        assert!(pkg.integrity_data_url.is_none());
+        let serialized = serde_json::to_string(&pkg).unwrap();
+        let round: Package = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(pkg, round);
+    }
+}


### PR DESCRIPTION
## Summary
- mirror several Mist Swift models in Rust with serde support
- add unit tests verifying round-trip serialization of the models

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_68b41fcdbbf0832995dd6dbb4007815d