### PR TITLE
feat: add streaming downloads and chunklist verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,6 +283,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,9 +318,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -643,7 +665,9 @@ name = "mist-core"
 version = "0.1.0"
 dependencies = [
  "fs_extra",
+ "futures-util",
  "reqwest",
+ "ring",
  "serde",
  "serde_json",
  "tempfile",
@@ -830,12 +854,29 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -991,6 +1032,12 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1166,6 +1213,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "url"
 version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,6 +1344,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,6 +1365,28 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,9 +6,11 @@ edition = "2021"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", features = ["json", "stream"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs"] }
 fs_extra = "1"
+futures-util = "0.3"
+ring = "0.16"
 
 [dev-dependencies]
 tempfile = "3"

--- a/core/src/helpers/chunklist.rs
+++ b/core/src/helpers/chunklist.rs
@@ -1,0 +1,47 @@
+use std::convert::TryInto;
+
+pub struct Chunk {
+    pub size: u32,
+    pub hash: [u8; 32],
+}
+
+pub struct Chunklist {
+    pub chunks: Vec<Chunk>,
+}
+
+impl Chunklist {
+    pub fn from_bytes(data: &[u8]) -> Result<Self, Box<dyn std::error::Error>> {
+        if data.len() < 0x24 {
+            return Err("chunklist too small".into());
+        }
+
+        let magic = u32::from_be_bytes(data[0x00..0x04].try_into()?);
+        if magic != 0x4C4B4E43 {
+            return Err("invalid magic header".into());
+        }
+
+        let total_chunks = u64::from_be_bytes(data[0x0C..0x14].try_into()?);
+        let chunks_offset = u64::from_be_bytes(data[0x14..0x1C].try_into()?);
+        let signature_offset = u64::from_be_bytes(data[0x1C..0x24].try_into()?);
+
+        if chunks_offset as usize != 0x24 {
+            return Err("invalid chunks offset".into());
+        }
+
+        if signature_offset as usize != chunks_offset as usize + total_chunks as usize * 0x24 {
+            return Err("invalid signature offset".into());
+        }
+
+        let mut chunks = Vec::new();
+        let mut pos = chunks_offset as usize;
+        for _ in 0..total_chunks {
+            let size = u32::from_be_bytes(data[pos..pos + 4].try_into()?);
+            let mut hash = [0u8; 32];
+            hash.copy_from_slice(&data[pos + 4..pos + 36]);
+            chunks.push(Chunk { size, hash });
+            pos += 36;
+        }
+
+        Ok(Self { chunks })
+    }
+}

--- a/core/src/helpers/download_manager.rs
+++ b/core/src/helpers/download_manager.rs
@@ -1,6 +1,8 @@
+use futures_util::TryStreamExt;
 use reqwest::Client;
 use std::path::Path;
-use tokio::fs;
+use tokio::fs::File;
+use tokio::io::AsyncWriteExt;
 
 pub struct DownloadManager {
     client: Client,
@@ -14,8 +16,18 @@ impl DownloadManager {
     }
 
     pub async fn download(&self, url: &str, dest: &Path) -> Result<(), Box<dyn std::error::Error>> {
-        let bytes = self.client.get(url).send().await?.bytes().await?;
-        fs::write(dest, &bytes).await?;
+        if dest.exists() {
+            return Ok(());
+        }
+
+        let response = self.client.get(url).send().await?;
+        let mut file = File::create(dest).await?;
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.try_next().await? {
+            file.write_all(&chunk).await?;
+        }
+
+        file.flush().await?;
         Ok(())
     }
 }

--- a/core/src/helpers/mod.rs
+++ b/core/src/helpers/mod.rs
@@ -4,3 +4,5 @@ pub mod download_manager;
 pub mod file_manager;
 pub mod launchd;
 pub mod sparkle;
+pub mod chunklist;
+pub mod validator;

--- a/core/src/helpers/validator.rs
+++ b/core/src/helpers/validator.rs
@@ -1,0 +1,32 @@
+use std::path::Path;
+
+use ring::digest::{self, SHA256};
+use tokio::fs::File;
+use tokio::io::AsyncReadExt;
+
+use crate::helpers::chunklist::Chunklist;
+
+pub async fn validate_package(
+    package: &Path,
+    chunklist: &Chunklist,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut file = File::open(package).await?;
+    for chunk in &chunklist.chunks {
+        let mut buf = vec![0u8; chunk.size as usize];
+        file.read_exact(&mut buf).await?;
+        let digest = digest::digest(&SHA256, &buf);
+        if digest.as_ref() != chunk.hash {
+            return Err("invalid chunk checksum".into());
+        }
+    }
+    Ok(())
+}
+
+pub async fn validate_from_url(
+    package: &Path,
+    url: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let bytes = reqwest::get(url).await?.bytes().await?;
+    let chunklist = Chunklist::from_bytes(&bytes)?;
+    validate_package(package, &chunklist).await
+}

--- a/core/tests/chunklist.rs
+++ b/core/tests/chunklist.rs
@@ -1,0 +1,33 @@
+use mist_core::helpers::{chunklist::Chunklist, validator};
+use tempfile::tempdir;
+use tokio::fs;
+
+#[tokio::test]
+async fn verifies_chunklist() {
+    let dir = tempdir().unwrap();
+    let pkg_path = dir.path().join("pkg.bin");
+    fs::write(&pkg_path, b"hello world").await.unwrap();
+
+    // compute sha256
+    let digest = ring::digest::digest(&ring::digest::SHA256, b"hello world");
+    let mut hash = [0u8; 32];
+    hash.copy_from_slice(digest.as_ref());
+
+    // build chunklist bytes for single chunk
+    let mut data = Vec::new();
+    data.extend_from_slice(&0x4C4B4E43u32.to_be_bytes());
+    data.extend_from_slice(&0x00000024u32.to_be_bytes());
+    data.extend_from_slice(&[0x01, 0x01, 0x02, 0x00]);
+    let total_chunks: u64 = 1;
+    data.extend_from_slice(&total_chunks.to_be_bytes());
+    data.extend_from_slice(&0x0000000000000024u64.to_be_bytes());
+    let signature_offset = 0x24 + 0x24; // header + one chunk
+    data.extend_from_slice(&(signature_offset as u64).to_be_bytes());
+    data.extend_from_slice(&(11u32).to_be_bytes());
+    data.extend_from_slice(&hash);
+
+    let chunklist = Chunklist::from_bytes(&data).unwrap();
+    validator::validate_package(&pkg_path, &chunklist)
+        .await
+        .expect("validation");
+}


### PR DESCRIPTION
## Summary
- support streaming downloads using reqwest in `DownloadManager`
- implement chunklist parser and SHA256 validation with `ring`
- expose cross-platform validation API for CLI and GUI

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68b55182c8888329a97eaba497e98897