### PR TITLE
Add retryable download manager with progress tracking

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.11", features = ["json", "stream"] }
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs", "time", "sync"] }
 fs_extra = "1"
 futures-util = "0.3"
 ring = "0.16"

--- a/core/src/helpers/download_manager.rs
+++ b/core/src/helpers/download_manager.rs
@@ -1,33 +1,140 @@
 use futures_util::TryStreamExt;
+use reqwest::header::{CONTENT_LENGTH, RANGE};
 use reqwest::Client;
 use std::path::Path;
-use tokio::fs::File;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::fs::{File, OpenOptions};
 use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex;
+use tokio::time::sleep;
+
+#[derive(Default)]
+struct DownloadState {
+    retries: usize,
+    delay: Duration,
+    downloaded: u64,
+    total: u64,
+}
 
 pub struct DownloadManager {
     client: Client,
+    state: Arc<Mutex<DownloadState>>,
 }
 
 impl DownloadManager {
     pub fn new() -> Self {
         Self {
             client: Client::new(),
+            state: Arc::new(Mutex::new(DownloadState::default())),
         }
     }
 
     pub async fn download(&self, url: &str, dest: &Path) -> Result<(), Box<dyn std::error::Error>> {
+        self.download_with_retry(url, dest, 1, 0).await
+    }
+
+    pub async fn download_with_retry(
+        &self,
+        url: &str,
+        dest: &Path,
+        retries_max: usize,
+        delay_secs: u64,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        {
+            let mut state = self.state.lock().await;
+            state.retries = 0;
+            state.delay = Duration::from_secs(delay_secs);
+            state.downloaded = 0;
+            state.total = 0;
+        }
+
+        let head = self.client.head(url).send().await?.error_for_status()?;
+        let total = head
+            .headers()
+            .get(CONTENT_LENGTH)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(0);
+
+        {
+            let mut state = self.state.lock().await;
+            state.total = total;
+        }
+
         if dest.exists() {
-            return Ok(());
+            let meta = tokio::fs::metadata(dest).await?;
+            if meta.len() == total {
+                let mut state = self.state.lock().await;
+                state.downloaded = total;
+                return Ok(());
+            }
         }
 
-        let response = self.client.get(url).send().await?;
-        let mut file = File::create(dest).await?;
-        let mut stream = response.bytes_stream();
-        while let Some(chunk) = stream.try_next().await? {
-            file.write_all(&chunk).await?;
-        }
+        let delay = Duration::from_secs(delay_secs);
+        let mut retries = 0usize;
+        loop {
+            let downloaded = if dest.exists() {
+                tokio::fs::metadata(dest).await?.len()
+            } else {
+                0
+            };
 
-        file.flush().await?;
-        Ok(())
+            {
+                let mut state = self.state.lock().await;
+                state.downloaded = downloaded;
+            }
+
+            let mut file = if downloaded > 0 {
+                OpenOptions::new().append(true).open(dest).await?
+            } else {
+                File::create(dest).await?
+            };
+
+            let mut req = self.client.get(url);
+            if downloaded > 0 {
+                req = req.header(RANGE, format!("bytes={}-", downloaded));
+            }
+
+            let resp = req.send().await;
+
+            match resp {
+                Ok(resp) => match resp.error_for_status() {
+                    Ok(ok) => {
+                        let mut stream = ok.bytes_stream();
+                        let mut downloaded = downloaded;
+                        while let Some(chunk) = stream.try_next().await? {
+                            file.write_all(&chunk).await?;
+                            downloaded += chunk.len() as u64;
+                            let mut state = self.state.lock().await;
+                            state.downloaded = downloaded;
+                        }
+                        file.flush().await?;
+                        return Ok(());
+                    }
+                    Err(_) => {}
+                },
+                Err(_) => {}
+            }
+
+            retries += 1;
+            {
+                let mut state = self.state.lock().await;
+                state.retries = retries;
+            }
+            if retries >= retries_max {
+                return Err("maximum retries reached".into());
+            }
+            sleep(delay).await;
+        }
+    }
+
+    pub async fn progress(&self) -> f64 {
+        let state = self.state.lock().await;
+        if state.total == 0 {
+            0.0
+        } else {
+            state.downloaded as f64 / state.total as f64
+        }
     }
 }

--- a/core/tests/download.rs
+++ b/core/tests/download.rs
@@ -1,6 +1,6 @@
 use mist_core::helpers::download_manager::DownloadManager;
-use tempfile::tempdir;
 use mockito::Server;
+use tempfile::tempdir;
 
 #[tokio::test]
 async fn downloads_file() {
@@ -8,7 +8,13 @@ async fn downloads_file() {
     let dest = dir.path().join("file.txt");
 
     let mut server = Server::new_async().await;
-    let _m = server
+    let _head = server
+        .mock("HEAD", "/file")
+        .with_status(200)
+        .with_header("content-length", "9")
+        .create_async()
+        .await;
+    let _get = server
         .mock("GET", "/file")
         .with_status(200)
         .with_body("test-data")
@@ -22,4 +28,79 @@ async fn downloads_file() {
     assert!(dest.exists());
     let contents = tokio::fs::read_to_string(&dest).await.unwrap();
     assert_eq!(contents, "test-data");
+}
+
+#[tokio::test]
+async fn retries_on_failure() {
+    let dir = tempdir().expect("temp dir");
+    let dest = dir.path().join("file.txt");
+
+    let mut server = Server::new_async().await;
+    let _head1 = server
+        .mock("HEAD", "/retry")
+        .with_status(200)
+        .with_header("content-length", "9")
+        .create_async()
+        .await;
+    let _get_fail = server
+        .mock("GET", "/retry")
+        .with_status(500)
+        .create_async()
+        .await;
+    let _head2 = server
+        .mock("HEAD", "/retry")
+        .with_status(200)
+        .with_header("content-length", "9")
+        .create_async()
+        .await;
+    let _get_ok = server
+        .mock("GET", "/retry")
+        .with_status(200)
+        .with_body("test-data")
+        .create_async()
+        .await;
+
+    let manager = DownloadManager::new();
+    let url = format!("{}/retry", server.url());
+    manager
+        .download_with_retry(&url, &dest, 2, 0)
+        .await
+        .expect("download");
+
+    assert!(dest.exists());
+    let contents = tokio::fs::read_to_string(&dest).await.unwrap();
+    assert_eq!(contents, "test-data");
+}
+
+#[tokio::test]
+async fn reports_progress() {
+    let dir = tempdir().expect("temp dir");
+    let dest = dir.path().join("file.txt");
+
+    let mut server = Server::new_async().await;
+    let _head = server
+        .mock("HEAD", "/progress")
+        .with_status(200)
+        .with_header("content-length", "9")
+        .create_async()
+        .await;
+    let _get = server
+        .mock("GET", "/progress")
+        .with_status(200)
+        .with_body("test-data")
+        .create_async()
+        .await;
+
+    let manager = DownloadManager::new();
+    let progress_before = manager.progress().await;
+    assert_eq!(progress_before, 0.0);
+
+    let url = format!("{}/progress", server.url());
+    manager
+        .download_with_retry(&url, &dest, 1, 0)
+        .await
+        .expect("download");
+
+    let progress_after = manager.progress().await;
+    assert_eq!(progress_after, 1.0);
 }


### PR DESCRIPTION
## Summary
- track retries, delay, and progress in DownloadManager
- add retryable `download_with_retry` and progress reporting
- cover retries and progress with unit tests

## Testing
- `cargo test -q`

------
https://chatgpt.com/codex/tasks/task_b_68b6ace1dc208329a7c7021090b26343