### PR TITLE
Add async TaskManager with progress hooks and tests

### DIFF
--- a/core/src/helpers/task_manager.rs
+++ b/core/src/helpers/task_manager.rs
@@ -1,46 +1,134 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::Mutex;
+
+use tokio::sync::{mpsc, Mutex};
 use tokio::task::JoinHandle;
 use uuid::Uuid;
 
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+/// Callback invoked with task progress updates.
+pub type ProgressHook = Arc<dyn Fn(Uuid, f32) + Send + Sync>;
+/// Callback invoked when a task reports an error.
+pub type ErrorHook = Arc<dyn Fn(Uuid, String) + Send + Sync>;
+/// Callback invoked when a task is cancelled.
+pub type CancelHook = Arc<dyn Fn(Uuid) + Send + Sync>;
+
+struct ManagedTask {
+    handle: JoinHandle<Result<(), BoxError>>,
+}
+
 /// Manages asynchronous tasks spawned via `tokio`.
-#[derive(Default, Clone)]
+#[derive(Clone, Default)]
 pub struct TaskManager {
-    tasks: Arc<Mutex<HashMap<Uuid, JoinHandle<()>>>>,
+    tasks: Arc<Mutex<HashMap<Uuid, ManagedTask>>>,
+    on_progress: Option<ProgressHook>,
+    on_error: Option<ErrorHook>,
+    on_cancel: Option<CancelHook>,
 }
 
 impl TaskManager {
     /// Create a new [`TaskManager`].
     pub fn new() -> Self {
-        Self {
-            tasks: Arc::new(Mutex::new(HashMap::new())),
-        }
+        Self::default()
+    }
+
+    /// Set a callback for progress updates.
+    pub fn on_progress<F>(&mut self, f: F)
+    where
+        F: Fn(Uuid, f32) + Send + Sync + 'static,
+    {
+        self.on_progress = Some(Arc::new(f));
+    }
+
+    /// Set a callback for task errors.
+    pub fn on_error<F>(&mut self, f: F)
+    where
+        F: Fn(Uuid, String) + Send + Sync + 'static,
+    {
+        self.on_error = Some(Arc::new(f));
+    }
+
+    /// Set a callback for task cancellation.
+    pub fn on_cancel<F>(&mut self, f: F)
+    where
+        F: Fn(Uuid) + Send + Sync + 'static,
+    {
+        self.on_cancel = Some(Arc::new(f));
     }
 
     /// Spawn a new asynchronous task and return its identifier.
-    pub async fn spawn<F>(&self, fut: F) -> Uuid
+    ///
+    /// The provided closure receives a [`mpsc::UnboundedSender`] which can
+    /// be used to report progress as a float between 0.0 and 1.0.
+    pub async fn spawn<F, Fut>(&self, f: F) -> Uuid
     where
-        F: std::future::Future<Output = ()> + Send + 'static,
+        F: FnOnce(mpsc::UnboundedSender<f32>) -> Fut + Send + 'static,
+        Fut: std::future::Future<Output = Result<(), BoxError>> + Send + 'static,
     {
         let id = Uuid::new_v4();
-        let handle = tokio::spawn(fut);
-        self.tasks.lock().await.insert(id, handle);
+        let progress_id = id.clone();
+        let error_id = id.clone();
+
+        let (tx, mut rx) = mpsc::unbounded_channel::<f32>();
+
+        if let Some(progress_hook) = self.on_progress.clone() {
+            tokio::spawn(async move {
+                while let Some(p) = rx.recv().await {
+                    (progress_hook)(progress_id, p);
+                }
+            });
+        } else {
+            tokio::spawn(async move {
+                while rx.recv().await.is_some() {}
+            });
+        }
+
+        let error_hook = self.on_error.clone();
+        let handle = tokio::spawn(async move {
+            let result = f(tx).await;
+            if let Err(ref e) = result {
+                if let Some(hook) = error_hook {
+                    hook(error_id, e.to_string());
+                }
+            }
+            result
+        });
+
+        self.tasks
+            .lock()
+            .await
+            .insert(id.clone(), ManagedTask { handle });
+
         id
     }
 
     /// Cancel a running task if it exists.
     pub async fn cancel(&self, id: Uuid) {
-        if let Some(handle) = self.tasks.lock().await.remove(&id) {
-            handle.abort();
+        if let Some(task) = self.tasks.lock().await.remove(&id) {
+            task.handle.abort();
+            if let Some(cb) = &self.on_cancel {
+                cb(id);
+            }
         }
     }
 
     /// Wait for a task to finish and remove it from management.
-    pub async fn join(&self, id: Uuid) -> Result<(), Box<dyn std::error::Error>> {
-        if let Some(handle) = self.tasks.lock().await.remove(&id) {
-            handle.await?;
+    pub async fn join(&self, id: Uuid) -> Result<(), BoxError> {
+        if let Some(task) = self.tasks.lock().await.remove(&id) {
+            match task.handle.await {
+                Ok(res) => res,
+                Err(e) => {
+                    if e.is_cancelled() {
+                        Ok(())
+                    } else {
+                        Err(Box::new(e))
+                    }
+                }
+            }
+        } else {
+            Ok(())
         }
-        Ok(())
     }
 }
+

--- a/core/tests/task_manager.rs
+++ b/core/tests/task_manager.rs
@@ -1,0 +1,86 @@
+use std::io;
+use std::sync::{Arc, Mutex};
+
+use mist_core::helpers::task_manager::TaskManager;
+use tokio::time::{sleep, Duration};
+
+#[tokio::test]
+async fn multiple_concurrent_tasks() {
+    let mut manager = TaskManager::new();
+
+    let progress = Arc::new(Mutex::new(Vec::new()));
+    let errors = Arc::new(Mutex::new(Vec::new()));
+    let cancellations = Arc::new(Mutex::new(Vec::new()));
+
+    {
+        let progress = progress.clone();
+        manager.on_progress(move |id, p| {
+            progress.lock().unwrap().push((id, p));
+        });
+    }
+
+    {
+        let errors = errors.clone();
+        manager.on_error(move |id, err| {
+            errors.lock().unwrap().push((id, err));
+        });
+    }
+
+    {
+        let cancellations = cancellations.clone();
+        manager.on_cancel(move |id| {
+            cancellations.lock().unwrap().push(id);
+        });
+    }
+
+    // Task 1: completes successfully and reports progress
+    let id_ok = manager
+        .spawn(|tx| async move {
+            for i in 0..=5 {
+                tx.send(i as f32 / 5.0).unwrap();
+                sleep(Duration::from_millis(10)).await;
+            }
+            Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
+        })
+        .await;
+
+    // Task 2: fails immediately
+    let id_err = manager
+        .spawn(|tx| async move {
+            tx.send(0.2).unwrap();
+            Err::<(), Box<dyn std::error::Error + Send + Sync>>(io::Error::new(io::ErrorKind::Other, "fail").into())
+        })
+        .await;
+
+    // Task 3: long running, will be cancelled
+    let id_cancel = manager
+        .spawn(|tx| async move {
+            loop {
+                tx.send(0.0).unwrap();
+                sleep(Duration::from_millis(50)).await;
+            }
+            #[allow(unreachable_code)]
+            Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
+        })
+        .await;
+
+    sleep(Duration::from_millis(120)).await;
+
+    manager.cancel(id_cancel).await;
+
+    manager.join(id_ok).await.expect("join ok");
+    assert!(manager.join(id_err).await.is_err());
+    manager.join(id_cancel).await.expect("join cancel");
+
+    let progress = progress.lock().unwrap().clone();
+    assert!(progress.iter().any(|(id, p)| *id == id_ok && (*p - 1.0).abs() < f32::EPSILON));
+
+    let errors = errors.lock().unwrap();
+    assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0].0, id_err);
+
+    let cancellations = cancellations.lock().unwrap();
+    assert_eq!(cancellations.len(), 1);
+    assert_eq!(cancellations[0], id_cancel);
+}
+


### PR DESCRIPTION
## Summary
- implement tokio-based TaskManager that tracks tasks and exposes progress, error and cancellation callbacks
- add integration test covering concurrent tasks with completion, failure and cancellation scenarios

## Testing
- `cargo test`
- `cargo test --test task_manager`


------
https://chatgpt.com/codex/tasks/task_b_68b6b741cf248329847dc6becb4924c0