### PR TITLE
feat(cli): add export and cache subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2511,6 +2511,9 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "mist-core",
+ "serde",
+ "serde_json",
+ "serde_yaml",
  "tokio",
 ]
 

--- a/core/src/installers.rs
+++ b/core/src/installers.rs
@@ -1,8 +1,9 @@
 use std::path::Path;
 
 use crate::helpers::download_manager::DownloadManager;
+use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Installer {
     pub id: usize,
     pub name: String,
@@ -11,6 +12,13 @@ pub struct Installer {
 
 /// Return a list of available installers.
 /// In the future this should query Apple's catalogs. Currently uses a static list for demonstration.
+///
+/// # Examples
+/// ```
+/// use mist_core::installers::list_installers;
+/// let installers = list_installers();
+/// assert!(installers.len() >= 1);
+/// ```
 pub fn list_installers() -> Vec<Installer> {
     vec![
         Installer {
@@ -27,6 +35,15 @@ pub fn list_installers() -> Vec<Installer> {
 }
 
 /// Download the installer with the specified `id` to `dest`.
+///
+/// # Examples
+/// ```no_run
+/// use std::path::Path;
+/// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+/// mist_core::installers::download_installer(1, Path::new("installer.pkg")).await?;
+/// # Ok(())
+/// # }
+/// ```
 pub async fn download_installer(id: usize, dest: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let installer = list_installers()
         .into_iter()
@@ -34,4 +51,30 @@ pub async fn download_installer(id: usize, dest: &Path) -> Result<(), Box<dyn st
         .ok_or_else(|| "installer not found".to_string())?;
     let manager = DownloadManager::new();
     manager.download(&installer.url, dest).await
+}
+
+/// Download the installer with retry options.
+///
+/// # Examples
+/// ```no_run
+/// use std::path::Path;
+/// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+/// mist_core::installers::download_installer_with_retry(1, Path::new("installer.pkg"), 3, 5).await?;
+/// # Ok(())
+/// # }
+/// ```
+pub async fn download_installer_with_retry(
+    id: usize,
+    dest: &Path,
+    retries: usize,
+    delay: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let installer = list_installers()
+        .into_iter()
+        .find(|i| i.id == id)
+        .ok_or_else(|| "installer not found".to_string())?;
+    let manager = DownloadManager::new();
+    manager
+        .download_with_retry(&installer.url, dest, retries, delay)
+        .await
 }

--- a/mist-rs/Cargo.toml
+++ b/mist-rs/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2021"
 mist-core = { path = "../core" }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_yaml = "0.9"

--- a/mist-rs/src/lib.rs
+++ b/mist-rs/src/lib.rs
@@ -1,0 +1,83 @@
+use clap::ValueEnum;
+use mist_core::{helpers::file_manager, installers};
+use std::path::{Path, PathBuf};
+
+/// Output formats for listing installers.
+#[derive(Clone, Debug, ValueEnum)]
+pub enum Format {
+    /// Plain text output
+    Text,
+    /// JSON formatted output
+    Json,
+    /// YAML formatted output
+    Yaml,
+}
+
+/// Export installers as a string in the given format, optionally filtered by name.
+///
+/// # Examples
+/// ```
+/// use mist_rs::{export_installers, Format};
+/// let data = export_installers(None, Format::Json).unwrap();
+/// assert!(data.contains("Rust Logo"));
+/// ```
+pub fn export_installers(
+    filter: Option<&str>,
+    format: Format,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let mut list = installers::list_installers();
+    if let Some(f) = filter {
+        let f = f.to_lowercase();
+        list.retain(|i| i.name.to_lowercase().contains(&f));
+    }
+    Ok(match format {
+        Format::Text => list
+            .into_iter()
+            .map(|i| format!("{}: {}", i.id, i.name))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        Format::Json => serde_json::to_string_pretty(&list)?,
+        Format::Yaml => serde_yaml::to_string(&list)?,
+    })
+}
+
+/// Download an installer by `id` with retry options.
+///
+/// # Examples
+/// ```no_run
+/// use std::path::Path;
+/// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+/// mist_rs::download_firmware(1, Path::new("installer.pkg"), 3, 5).await?;
+/// # Ok(())
+/// # }
+/// ```
+pub async fn download_firmware(
+    id: usize,
+    dest: &Path,
+    retries: usize,
+    delay: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    installers::download_installer_with_retry(id, dest, retries, delay).await
+}
+
+/// Remove the cache directory.
+///
+/// # Examples
+/// ```
+/// use std::path::Path;
+/// let dir = std::env::temp_dir().join("mist-cache-doc");
+/// std::fs::create_dir_all(&dir).unwrap();
+/// mist_rs::clear_cache(Some(&dir)).unwrap();
+/// assert!(!dir.exists());
+/// ```
+pub fn clear_cache(path: Option<&Path>) -> Result<(), Box<dyn std::error::Error>> {
+    let cache_path: PathBuf = match path {
+        Some(p) => p.to_path_buf(),
+        None => {
+            let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
+            PathBuf::from(home).join(".cache/mist")
+        }
+    };
+    file_manager::remove_dir_all(&cache_path)?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add installer export and cache commands to CLI
- allow download retries and list filtering with format options
- document core and CLI helpers with examples

## Testing
- `cargo test -p mist-core -p mist-rs`


------
https://chatgpt.com/codex/tasks/task_b_68b7ae6ac1c08329844d60b95fbbcaaa