### PR TITLE
Expand cross-platform builds and targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,14 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-gnu
             bin: mist.exe
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            bin: mist.exe
           - os: macos-13
             target: x86_64-apple-darwin
+            bin: mist
+          - os: macos-14
+            target: aarch64-apple-darwin
             bin: mist
     runs-on: ${{ matrix.os }}
     defaults:

--- a/README-rust.md
+++ b/README-rust.md
@@ -15,3 +15,24 @@ After installing the prerequisites, you can verify the workspace builds with:
 ```bash
 cargo check
 ```
+
+## Cross-compilation
+
+Additional targets can be installed with `rustup`:
+
+```bash
+rustup target add x86_64-unknown-linux-gnu \
+    x86_64-pc-windows-msvc \
+    aarch64-apple-darwin
+```
+
+For a consistent experience across platforms, install [`cross`](https://github.com/cross-rs/cross):
+
+```bash
+cargo install cross
+cross test --target x86_64-pc-windows-msvc
+cross build --release --target aarch64-apple-darwin
+```
+
+Windows builds require the Visual Studio Build Tools and macOS builds require
+Xcode and its command line tools.


### PR DESCRIPTION
## Summary
- add Windows MSVC and macOS ARM targets to CI matrix
- document cross-compilation workflow with `rustup` targets and `cross`

## Testing
- `rustup target add x86_64-unknown-linux-gnu x86_64-pc-windows-msvc aarch64-apple-darwin`
- `cargo check --manifest-path mist-rs/Cargo.toml --target x86_64-unknown-linux-gnu`
- `cargo check --target x86_64-pc-windows-msvc` *(fails: missing `lib.exe`)*
- `cargo check --target aarch64-apple-darwin` *(fails: unsupported `cc` flags)*
- `cargo test --no-run`

------
https://chatgpt.com/codex/tasks/task_b_68b7b3c2abdc8329b81385c993a27040